### PR TITLE
FIX: attributesignal describe from ophyd PR

### DIFF
--- a/hkl/diffract.py
+++ b/hkl/diffract.py
@@ -25,11 +25,25 @@ class AttributeSignal(Signal):
     def __init__(self, attr, *, name=None, parent=None):
         super().__init__(name=name, parent=parent)
 
-        self.attr_base, self.attr = attr.rsplit('.', 1)
+        if '.' in attr:
+            self.attr_base, self.attr = attr.rsplit('.', 1)
+        else:
+            self.attr_base, self.attr = None, attr
+
+    @property
+    def full_attr(self):
+        '''The full attribute name'''
+        if not self.attr_base:
+            return self.attr
+        else:
+            return '.'.join((self.attr_base, self.attr))
 
     @property
     def base(self):
         '''The parent instance which has the final attribute'''
+        if self.attr_base is None:
+            return self.parent
+
         obj = self.parent
         for i, part in enumerate(self.attr_base.split('.')):
             try:
@@ -48,10 +62,11 @@ class AttributeSignal(Signal):
 
     def describe(self):
         value = self.value
-        return {'source': 'PY:{}.{}'.format(self.parent.name, self.attr),
+        desc = {'source': 'PY:{}.{}'.format(self.parent.name, self.full_attr),
                 'dtype': data_type(value),
                 'shape': data_shape(value),
                 }
+        return {self.name: desc}
 
 
 class ArrayAttributeSignal(AttributeSignal):


### PR DESCRIPTION
Fixes `describe()` on `AttributeSignal`. This is in a PR upstream to NSLS-II/ophyd#321 and soon can be removed from hklpy.